### PR TITLE
Update to >=RN0.60.0 with Podspec

### DIFF
--- a/RCTSelectContact.podspec
+++ b/RCTSelectContact.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.requires_arc        = true
   s.platform            = :ios, "8.0"
   
-  s.dependency 'React-Core'
+  s.dependency 'React'
   
   s.subspec 'Core' do |ss|
     ss.source_files     = "ios/RCTSelectContact/*.{h,m}"

--- a/RCTSelectContact.podspec
+++ b/RCTSelectContact.podspec
@@ -1,0 +1,23 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name                = "RCTSelectContact"
+  s.version             = package['version']
+  s.summary             = "Simple iOS contact picker"
+  s.homepage            = "https://github.com/streem/react-native-select-contact"
+  s.license             = package['license']
+  s.author              = package['author']
+  s.source              = { :git => 'https://github.com/streem/react-native-select-contact.git', :tag => "v#{s.version}" }
+  s.default_subspec     = 'Core'
+  s.requires_arc        = true
+  s.platform            = :ios, "8.0"
+  
+  s.dependency 'React-Core'
+  
+  s.subspec 'Core' do |ss|
+    ss.source_files     = "ios/RCTSelectContact/*.{h,m}"
+  end
+
+end


### PR DESCRIPTION
Allows installation into the latest RN projects using pod install. This is the new recommended method for libraries moving forward in RN 0.60.0 or above.

Tested on RN 0.60.3