### PR TITLE
add React Native v0.60.0 as part of peer dependecy

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
     }
   ],
   "peerDependencies": {
-    "react-native": "^0.51.0"
+    "react-native": ">=0.51.0"
   },
   "devDependencies": {
-    "react-native": "^0.51.0"
+    "react-native": ">=0.51.0"
   },
   "optionalDependencies": {
     "@yfuks/react-native-action-sheet": "^0.0.4"


### PR DESCRIPTION
If you install on RN v0.60.0+ you would get this warning: 
`warning " > react-native-select-contact@1.2.1" has incorrect peer dependency "react-native@^0.51.0".`