### PR TITLE
Load Android Gradle Plugin conditionally

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,20 +1,24 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
+    // The Android Gradle plugin is only required when opening the android folder stand-alone.
+    // This avoids unnecessary downloads and potential conflicts when the library is included as a
+    // module dependency in an application project.
+    if (project == rootProject) {
+        repositories {
+            google()
+            jcenter()
+        }
+        dependencies {
+            classpath("com.android.tools.build:gradle:3.6.1")
+        }
     }
 }
 
 allprojects {
     repositories {
         mavenLocal()
+        google()
         jcenter()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm


### PR DESCRIPTION
- Load Android Gradle Plugin conditionally

This wraps the Android Gradle plugin dependency in the buildscripts section of android/build.gradle in a conditional:

```
if (project == rootProject) {
    // ... (dependency here)
}
```

The Android Gradle plugin is only required when opening the project stand-alone, not when it is included as a dependency. By doing this, the project opens correctly in Android Studio, and it can also be consumed as a native module dependency from an application project without affecting the app project (avoiding unnecessary downloads/conflicts/etc).

for more info, you can refer to [this thread](https://github.com/facebook/react-native/pull/25569) and especially [this comment.](https://github.com/facebook/react-native/pull/25569#issuecomment-532504277)