### PR TITLE
Remove tintColor config for ActionSheet

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,7 +125,6 @@ function selectPhone(phones) {
                 title: 'Select Phone',
                 options: options,
                 cancelButtonIndex: options.length - 1,
-                tintColor: 'blue'
             },
             (buttonIndex) => {
                 resolve(phones[buttonIndex]);
@@ -157,7 +156,6 @@ function selectPostalAddress(addresses) {
               title: 'Select Postal Address',
               options: options,
               cancelButtonIndex: options.length - 1,
-              tintColor: 'blue'
           },
           (buttonIndex) => {
               resolve(addresses[buttonIndex]);
@@ -184,7 +182,6 @@ function selectEmail(emails) {
                 title: 'Select Email',
                 options: options,
                 cancelButtonIndex: options.length - 1,
-                tintColor: 'blue'
             },
             (buttonIndex) => {
                 resolve(emails[buttonIndex]);


### PR DESCRIPTION
When `tintColor: 'blue'` and the user is in iOS dark mode, the contrast is very difficult to read. `tintColor` is optional, so `ActionSheetIOS` will use good looking system defaults without it.

### Before (dark mode)
![Screen Shot 2021-06-01 at 2 07 32 PM](https://user-images.githubusercontent.com/16692671/120393234-6fddb700-c2e6-11eb-95da-1c433fc285f5.png)

### After (dark mode)
![Screen Shot 2021-06-01 at 2 07 52 PM](https://user-images.githubusercontent.com/16692671/120393259-79671f00-c2e6-11eb-8fcd-5544dfc017ee.png)

### After (light mode)
<img width="460" alt="Screen Shot 2021-06-01 at 2 35 02 PM" src="https://user-images.githubusercontent.com/16692671/120393318-91d73980-c2e6-11eb-8b47-bd0242d083fd.png">
