### PR TITLE
replaced deprecated jcenter repository with mavencentral

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
+            mavencentral()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.5.2'
@@ -43,7 +43,7 @@ repositories {
         url "$rootDir/../node_modules/jsc-android/dist"
     }
     google()
-    jcenter()
+    mavencentral()
 }
 
 dependencies {


### PR DESCRIPTION
replaced jCenter with mavenCentral. jCentral is having a pretty long outage and it's deprecated. Move on from jCenter and replace it with mavenCentral.